### PR TITLE
Feat: adding nix flake support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,40 @@ An alternative to the World Wide Web (`http(s)://`), with:
 # Download and Install
 ## Arch Linux
 - `yay -S napture`, it's available on AUR.
+## Nix[OS]
+
+**Flakes**: The repository provides a flake which exposes an overlay providing the webx package, so you could just add the input in your flake.nix file
+
+```nix
+{
+    inputs = {
+        webx.url = "github:face-hh/webx";
+    };
+}
+```
+
+Then add it to your overlays and install it
+
+```nix
+{ inputs, ... }: {
+    nixpkgs.overlays = [
+        inputs.webx.overlays.x86_64-linux.default
+    ];
+}
+```
+
+> For now, only tested on x86_64-linux, but may work on others aswell, just change the arch
+
+Add it to either home.packages (home manager) or environment.systemPackages (global packages).
+
+```nix
+home.packages = with pkgs; [
+    webx
+];
+```
+
+Then you could just launch it using `webx` in your terminal.
+
 ## Linux
 - For now, you have to download [Rust](https://www.rust-lang.org/tools/install). Then, you just need to open `install-linux` as an executable (if you can't execute it, first do `sudo chmod +x ./install-linux`, then you should be able to install).
 ## Windows

--- a/default.nix
+++ b/default.nix
@@ -28,5 +28,16 @@
     install -Dm644 $src/io.github.face_hh.Napture.metainfo.xml -t $out/share/metainfo/
     install -Dm644 $src/io.github.face_hh.Napture.desktop -t $out/share/applications/
     install -Dm644 $src/io.github.face_hh.Napture.svg -t $out/share/icons/hicolor/scalable/apps/
+
+    # updating the `Exec` field
+    substituteInPlace $out/share/applications/io.github.face_hh.Napture.desktop \
+      --replace napture $out/bin/webx
   '';
+
+  meta = {
+    description = "An alternative for the World Wide Web";
+    license = lib.licenses.unlicense;
+    maintainers = [ lib.maintainers.alphatechnolog ]; # flake maintainer ig
+    mainProgram = "napture";
+  };
 }

--- a/default.nix
+++ b/default.nix
@@ -38,6 +38,6 @@
     description = "An alternative for the World Wide Web";
     license = lib.licenses.unlicense;
     maintainers = [ lib.maintainers.alphatechnolog ]; # flake maintainer ig
-    mainProgram = "napture";
+    mainProgram = "webx";
   };
 }

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, lib, pkgs ? import <nixpkgs> {}, ... }: pkgs.rustPlatform.buildRustPackage {
+  pname = "webx";
+  version = "git";
+
+  src = "${pkgs.webx-src}/napture";
+
+  nativeBuildInputs = lib.optionals stdenv.isLinux (with pkgs; [
+    pkg-config
+  ]);
+
+  propagatedBuildInputs = lib.optionals stdenv.isLinux (with pkgs; [
+    glib
+    pango
+    gdk-pixbuf
+    openssl_3_3
+    graphene
+    gtk4
+    libadwaita
+    lua5_4_compat
+  ]);
+
+  cargoLock = {
+    lockFile = "${pkgs.webx-src}/napture/Cargo.lock";
+  };
+
+  postInstall = ''
+    mkdir -p $out/share/metainfo $out/share/applications $out/share/icons
+    install -Dm644 $src/io.github.face_hh.Napture.metainfo.xml -t $out/share/metainfo/
+    install -Dm644 $src/io.github.face_hh.Napture.desktop -t $out/share/applications/
+    install -Dm644 $src/io.github.face_hh.Napture.svg -t $out/share/icons/hicolor/scalable/apps/
+  '';
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,78 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1716948383,
+        "narHash": "sha256-SzDKxseEcHR5KzPXLwsemyTR/kaM9whxeiJohbL04rs=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "ad57eef4ef0659193044870c731987a6df5cf56b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "webx-src": "webx-src"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "webx-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1717155534,
+        "narHash": "sha256-mXZCyIzcZqXyosq+OtKKPyM/q+ZSDtzXGsvmQRapur4=",
+        "owner": "face-hh",
+        "repo": "webx",
+        "rev": "2ddaa59caf7ab43c42d8a557ca1529de68b10204",
+        "type": "github"
+      },
+      "original": {
+        "owner": "face-hh",
+        "repo": "webx",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,41 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+
+    webx-src = {
+      url = "github:face-hh/webx";
+      flake = false;
+    };
+  };
+
+  outputs = { self, nixpkgs, flake-utils, ... } @inputs: flake-utils.lib.eachDefaultSystem(system: let
+    pkgs = import nixpkgs {inherit system overlays;};
+    package = pkgs.callPackage ./default.nix {};
+
+    overlays = [
+      (_: _: {
+        inherit (inputs) webx-src;
+      })
+    ];
+  in {
+    packages.default = package;
+
+    devShells.default = let inherit (pkgs) mkShell; in mkShell {
+      name = "dev";
+      nativeBuildInputs = [pkgs.pkg-config];
+      buildInputs = with pkgs; [package cargo rustc];
+
+      propagatedBuildInputs = with pkgs; [
+        glib
+        pango
+        gdk-pixbuf
+        openssl_3_3
+        graphene
+        gtk4
+        libadwaita
+        lua5_4_compat
+      ];
+    };
+  });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -11,19 +11,19 @@
 
   outputs = { self, nixpkgs, flake-utils, ... } @inputs: flake-utils.lib.eachDefaultSystem(system: let
     pkgs = import nixpkgs {inherit system overlays;};
+
+    # same as the one in the overlay but with the current pkgs iteration (current system).
     package = pkgs.callPackage ./default.nix {};
 
-    overlays = [
-      (_: _: {
-        inherit (inputs) webx-src;
-      })
-    ];
-  in {
-    packages.default = package;
+    overlays = [mainOverlay];
 
-    overlays.default = (final: _: {
+    mainOverlay = (final: _: {
+      inherit (inputs) webx-src;
       webx = final.callPackage ./default.nix {};
     });
+  in {
+    packages.default = package;
+    overlays.default = mainOverlay;
 
     devShells.default = let inherit (pkgs) mkShell; in mkShell {
       name = "dev";

--- a/flake.nix
+++ b/flake.nix
@@ -21,8 +21,8 @@
   in {
     packages.default = package;
 
-    overlays.default = (_: _: {
-      webx = package;
+    overlays.default = (final: _: {
+      webx = final.callPackage ./default.nix {};
     });
 
     devShells.default = let inherit (pkgs) mkShell; in mkShell {

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,10 @@
   in {
     packages.default = package;
 
+    overlays.default = (_: _: {
+      webx = package;
+    });
+
     devShells.default = let inherit (pkgs) mkShell; in mkShell {
       name = "dev";
       nativeBuildInputs = [pkgs.pkg-config];


### PR DESCRIPTION
This PR adds support for nix by providing a flake that exposes a derivation to build the package automatically, instructions have been detailed in the README.md (changes included in this PR), anyways here's a little resume on how to install it

1. Add webx to the flake inputs
2. Include `inputs.webx.overlays.x86_64-linux.default` to `nixpkgs.overlays`
3. Install `pkgs.webx` inside `environment.systemPackages` or `home.packages`.

If using without a nixos system directly, one could also use `inputs.webx.packages.x86_64-linux.default` to install it directly somewhere else, either it's a dev shell or whatever.