### PR TITLE
feat: add experimental macOS install script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install deps
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libpango1.0-dev libgtk-4-dev libgraphene-1.0-dev libadwaita-1-dev liblua5.4-dev
+          sudo apt update
+          sudo apt install -y libpango1.0-dev libgtk-4-dev libgraphene-1.0-dev libadwaita-1-dev liblua5.4-dev pkg-config
       - name: Build Napture
         run: |
           cd napture
@@ -49,7 +49,7 @@ jobs:
         run: |
           brew install gtk4 graphene glib libadwaita lua create-dmg pkg-config
           arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-          arch -x86_64 /usr/local/bin/brew install gtk4 graphene glib libadwaita lua pkg-config
+          arch -x86_64 /usr/local/bin/brew install gtk4 graphene glib libadwaita lua pkg-config || exit 0 # Brew tries to link python which will fail
       - name: Build Napture
         run: |
           rustup target add x86_64-apple-darwin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,83 @@
+name: Build Napture Nightly
+
+on:
+  push:
+    branches: ['master']
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-linux-x86_64:
+    name: Build linux-x86_64
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build Napture
+        run: |
+          cd napture
+          cargo build --release --verbose
+      - name: Pack Napture into AppImage
+        run: |
+          cd napture/target/release
+          mkdir -p io.github.face_hh.Napture.AppDir/usr/bin/
+          mkdir -p io.github.face_hh.Napture.AppDir/usr/share/metainfo/
+          cp webx io.github.face_hh.Napture.AppDir/usr/bin/nepture
+          cp ../../io.github.face_hh.Napture.metainfo.xml io.github.face_hh.Napture.AppDir/usr/share/metainfo/
+          cp ../../io.github.face_hh.Napture.desktop io.github.face_hh.Napture.AppDir/
+          cp ../../io.github.face_hh.Napture.svg io.github.face_hh.Napture.AppDir/
+          wget "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage"
+          chmod a+x appimagetool-x86_64.AppImage
+          ./appimagetool-x86_64.AppImage io.github.face_hh.Napture.AppDir Napture-linux-x86_64.AppImage
+      - name: Upload Napture AppImage
+        uses: actions/upload-artifact@v2
+        with:
+          name: Napture-linux-x86_64
+          path: napture/target/release/Napture-linux-x86_64.AppImage
+  build-macos-universial:
+    name: Build macos-universial
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install deps
+        run: |
+          brew install gtk4 graphene glib libadwaita lua create-dmg
+          arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+          arch -x86_64 brew install gtk4 graphene glib libadwaita lua
+      - name: Build Napture
+        run: |
+          rustup target add x86_64-apple-darwin
+          cd napture
+          RUSTFLAGS='-L /opt/homebrew/Cellar/' cargo build --release --target aarch64-apple-darwin
+          PKG_CONFIG='/usr/local/bin/pkg-config' RUSTFLAGS='-L /usr/local/Cellar/' cargo build --release --target x86_64-apple-darwin
+          lipo -create target/aarch64-apple-darwin/release/webx target/x86_64-apple-darwin/release/webx -output target/release/webx
+      - name: Make an app bundle
+        run: |
+          cd napture
+          mkdir -p target/release/Napture.app/Contents/MacOS
+          cp target/release/webx target/release/Napture.app/Contents/MacOS
+          cp ./Info.plist target/release/Napture.app/Contents
+          mkdir -p target/release/Napture.app/Contents/Resources/AppIcon.iconset
+
+          for SIZE in 16 32 64 128 256 512; do
+              sips -z $SIZE $SIZE ./file.png --out target/release/Napture.app/Contents/Resources/AppIcon.iconset/icon_${SIZE}x${SIZE}.png
+          done
+          for SIZE in 32 64 256 512; do
+              sips -z $SIZE $SIZE ./file.png --out target/release/Napture.app/Contents/Resources/AppIcon.iconset/icon_$(expr $SIZE / 2)x$(expr $SIZE / 2)x2.png
+          done
+
+          iconutil -c icns -o target/release/Napture.app/Contents/Resources/AppIcon.icns target/release/Napture.app/Contents/Resources/AppIcon.iconset
+          rm -rf target/release/Napture.app/Contents/Resources/AppIcon.iconset
+      - name: Sign the app
+        run: codesign --force --deep --sign - napture/target/release/Napture.app
+      - name: Pack Napture into DMG
+        run: |
+          cd napture/target/release
+          create-dmg Napture-macos-universial.dmg Napture.app
+      - name: Upload Napture DMG
+        uses: actions/upload-artifact@v2
+        with:
+          name: Napture-macos-universial
+          path: napture/target/release/Napture-macos-universial.dmg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,8 @@ jobs:
       - name: Install deps
         run: |
           sudo apt update
-          sudo apt install -y libpango1.0-dev libgtk-4-dev libgraphene-1.0-dev libadwaita-1-dev liblua5.4-dev pkg-config
+          sudo apt install -y build-essential pkg-config
+          sudo apt install -y libpango1.0-dev libgtk-4-dev libgraphene-1.0-dev libadwaita-1-dev liblua5.4-dev
       - name: Build Napture
         run: |
           cd napture
@@ -35,9 +36,9 @@ jobs:
           chmod a+x appimagetool-x86_64.AppImage
           ./appimagetool-x86_64.AppImage io.github.face_hh.Napture.AppDir Napture-linux-x86_64.AppImage
       - name: Upload Napture AppImage
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
-          name: Napture-linux-x86_64
+          name: Napture-linux-x86_64.AppImage
           path: napture/target/release/Napture-linux-x86_64.AppImage
   build-macos-universial:
     name: Build macos-universial
@@ -81,7 +82,7 @@ jobs:
           cd napture/target/release
           create-dmg Napture-macos-universial.dmg Napture.app
       - name: Upload Napture DMG
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
-          name: Napture-macos-universial
+          name: Napture-macos-universial.dmg
           path: napture/target/release/Napture-macos-universial.dmg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Install deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libpango1.0-dev
       - name: Build Napture
         run: |
           cd napture
@@ -43,9 +47,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install deps
         run: |
-          brew install gtk4 graphene glib libadwaita lua create-dmg
+          brew install gtk4 graphene glib libadwaita lua create-dmg pkg-config
           arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-          arch -x86_64 brew install gtk4 graphene glib libadwaita lua
+          arch -x86_64 brew install gtk4 graphene glib libadwaita lua pkg-config
       - name: Build Napture
         run: |
           rustup target add x86_64-apple-darwin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install deps
         run: |
           sudo apt-get update
-          sudo apt-get install -y libpango1.0-dev
+          sudo apt-get install -y libpango1.0-dev libgtk-4-dev libgraphene-1.0-dev libadwaita-1-dev liblua5.4-dev
       - name: Build Napture
         run: |
           cd napture
@@ -49,7 +49,7 @@ jobs:
         run: |
           brew install gtk4 graphene glib libadwaita lua create-dmg pkg-config
           arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-          arch -x86_64 brew install gtk4 graphene glib libadwaita lua pkg-config
+          arch -x86_64 /usr/local/bin/brew install gtk4 graphene glib libadwaita lua pkg-config
       - name: Build Napture
         run: |
           rustup target add x86_64-apple-darwin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Install deps
         run: |
           sudo apt update
+          sudo apt upgrade -y
           sudo apt install -y build-essential pkg-config
           sudo apt install -y libpango1.0-dev libgtk-4-dev libgraphene-1.0-dev libadwaita-1-dev liblua5.4-dev
       - name: Build Napture

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Then you could just launch it using `webx` in your terminal.
 
 ## Linux
 - For now, you have to download [Rust](https://www.rust-lang.org/tools/install). Then, you just need to open `install-linux` as an executable (if you can't execute it, first do `sudo chmod +x ./install-linux`, then you should be able to install).
+## macOS
+- For now, you have to download [Rust](https://www.rust-lang.org/tools/install) and [Homebrew](https://brew.sh). Then, you just need to open `install-macos` as an executable (if you can't execute it, first do `chmod +x ./install-macos`, then you should be able to install).
 ## Windows
 - Install the executable from the release tab. It's a self-extractor with WinRAR because it has a lot of DLLs.
 

--- a/install-macos
+++ b/install-macos
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+echo "Building Napture..."
+
+status=$(git status)
+
+# Check if the status contains the phrase "Your branch is behind"
+if [[ $status == *"Your branch is behind"* ]]; then
+    echo "Your branch is behind the remote repository."
+    echo "Pulling the latest changes..."
+    git pull origin $(git rev-parse --abbrev-ref HEAD)
+elif [[ $status == *"Your branch is up to date"* ]]; then
+    echo "Your branch is up to date with the remote repository."
+else
+    echo "Failed to determine the repository status."
+fi
+
+# Install deps using Homebrew
+brew install gtk4 graphene glib libadwaita lua || exit 1
+
+# Assuming the script is in the same directory as "napture"
+cd "$(dirname "$0")/napture" || exit 1
+
+# Build the project
+RUSTFLAGS="-L $HOMEBREW_CELLAR" cargo build --release || exit 1
+
+# Make an app bundle
+mkdir -p target/release/Napture.app/Contents/MacOS
+cp target/release/webx target/release/Napture.app/Contents/MacOS
+cp ./Info.plist target/release/Napture.app/Contents
+
+# Thanks https://stackoverflow.com/a/31883126/9376340
+
+mkdir -p target/release/Napture.app/Contents/Resources/AppIcon.iconset
+
+# Normal screen icons
+for SIZE in 16 32 64 128 256 512; do
+    sips -z $SIZE $SIZE ./file.png --out target/release/Napture.app/Contents/Resources/AppIcon.iconset/icon_${SIZE}x${SIZE}.png || exit 1
+done
+
+# Retina display icons
+for SIZE in 32 64 256 512; do
+    sips -z $SIZE $SIZE ./file.png --out target/release/Napture.app/Contents/Resources/AppIcon.iconset/icon_$(expr $SIZE / 2)x$(expr $SIZE / 2)x2.png || exit 1
+done
+
+# Make a multi-resolution Icon
+iconutil -c icns -o target/release/Napture.app/Contents/Resources/AppIcon.icns target/release/Napture.app/Contents/Resources/AppIcon.iconset || exit 1
+rm -rf target/release/Napture.app/Contents/Resources/AppIcon.iconset
+
+# Sign the app bundle
+codesign --force --deep --sign - target/release/Napture.app || exit 1
+
+# Move to Application folder
+
+echo "Installing Napture..."
+
+mv target/release/Napture.app /Applications || exit 1
+
+echo "Napture installation completed."

--- a/napture/Info.plist
+++ b/napture/Info.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>webx</string>
+	<key>CFBundleIdentifier</key>
+	<string>io.github.face_hh.Napture</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Napture</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>11.0</string>
+	<key>CFBundleIconFile</key>
+	<string>AppIcon</string>
+	<key>CFBundleIconName</key>
+	<string>AppIcon</string>
+</dict>
+</plist>


### PR DESCRIPTION
This PR adds experimental support for macOS. You can try this by running `install-macos` script in the root of this project. Which will do basically the same thing as `install-linux` except:
- Creating app icons
- Signing the app
- Moving the app to `/Applications`