### PR TITLE
feat: add experimental macOS install script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Then you could just launch it using `webx` in your terminal.
 
 ## Linux
 - For now, you have to download [Rust](https://www.rust-lang.org/tools/install). Then, you just need to open `install-linux` as an executable (if you can't execute it, first do `sudo chmod +x ./install-linux`, then you should be able to install).
+## macOS
+- For now, you have to download [Rust](https://www.rust-lang.org/tools/install) and [Homebrew](https://brew.sh). Then, you just need to open `install-macos` as an executable (if you can't execute it, first do `chmod +x ./install-macos`, then you should be able to install).
 ## Windows
 - Install the executable from the release tab. It's a self-extractor with WinRAR because it has a lot of DLLs.
 

--- a/install-macos
+++ b/install-macos
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+echo "Building Napture..."
+
+status=$(git status)
+
+# Check if the status contains the phrase "Your branch is behind"
+if [[ $status == *"Your branch is behind"* ]]; then
+    echo "Your branch is behind the remote repository."
+    echo "Pulling the latest changes..."
+    git pull origin $(git rev-parse --abbrev-ref HEAD)
+elif [[ $status == *"Your branch is up to date"* ]]; then
+    echo "Your branch is up to date with the remote repository."
+else
+    echo "Failed to determine the repository status."
+fi
+
+# Install deps using Homebrew
+brew install gtk4 graphene glib libadwaita lua || exit 1
+
+# Assuming the script is in the same directory as "napture"
+cd "$(dirname "$0")/napture" || exit 1
+
+# Build the project
+RUSTFLAGS="-L $HOMEBREW_CELLAR" cargo build --release || exit 1
+
+# Make an app bundle
+mkdir -p target/release/Napture.app/Contents/MacOS
+cp target/release/webx target/release/Napture.app/Contents/MacOS
+cp ./Info.plist target/release/Napture.app/Contents
+
+# Thanks https://stackoverflow.com/a/31883126/9376340
+
+mkdir -p target/release/Napture.app/Contents/Resources/AppIcon.iconset
+
+# Normal screen icons
+for SIZE in 16 32 64 128 256 512; do
+    sips -z $SIZE $SIZE ./file.png --out target/release/Napture.app/Contents/Resources/AppIcon.iconset/icon_${SIZE}x${SIZE}.png || exit 1
+done
+
+# Retina display icons
+for SIZE in 32 64 256 512; do
+    sips -z $SIZE $SIZE ./file.png --out target/release/Napture.app/Contents/Resources/AppIcon.iconset/icon_$(expr $SIZE / 2)x$(expr $SIZE / 2)x2.png || exit 1
+done
+
+# Make a multi-resolution Icon
+iconutil -c icns -o target/release/Napture.app/Contents/Resources/AppIcon.icns target/release/Napture.app/Contents/Resources/AppIcon.iconset || exit 1
+rm -rf target/release/Napture.app/Contents/Resources/AppIcon.iconset
+
+# Sign the app bundle
+codesign --force --deep --sign - target/release/Napture.app || exit 1
+
+# Move to Application folder
+
+echo "Installing Napture..."
+
+mv target/release/Napture.app /Applications || exit 1
+
+echo "Napture installation completed."

--- a/install-macos
+++ b/install-macos
@@ -16,7 +16,7 @@ else
 fi
 
 # Install deps using Homebrew
-brew install gtk4 graphene glib libadwaita lua || exit 1
+brew install gtk4 graphene glib libadwaita lua pkg-config || exit 1
 
 # Assuming the script is in the same directory as "napture"
 cd "$(dirname "$0")/napture" || exit 1

--- a/napture/Info.plist
+++ b/napture/Info.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>webx</string>
+	<key>CFBundleIdentifier</key>
+	<string>io.github.face_hh.Napture</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Napture</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>11.0</string>
+	<key>CFBundleIconFile</key>
+	<string>AppIcon</string>
+	<key>CFBundleIconName</key>
+	<string>AppIcon</string>
+</dict>
+</plist>


### PR DESCRIPTION
This PR adds experimental support for macOS. You can try this by running `install-macos` script in the root of this project. Which will do basically the same thing as `install-linux` except:
- Creating app icons
- Signing the app
- Moving the app to `/Applications`

Reopened from #65 