### PR TITLE
Fix: Allow changing one dimension of TextView/Entry independently

### DIFF
--- a/napture/src/b9/css.rs
+++ b/napture/src/b9/css.rs
@@ -412,8 +412,11 @@ impl Styleable for gtk::TextView {
                     let width = properties.width;
                     let height = properties.height;
 
-                    if width != 0 && height != 0 {
-                        self.set_size_request(width, height);
+                    if width > 0 || height > 0 {
+                        let normalized_width = if width > 0 { width } else { -1 };
+                        let normalized_height = if height > 0 { height } else { -1 };
+
+                        self.set_size_request(normalized_width, normalized_height);
                     }
 
                     self.set_margin_top(properties.margin_top.parse::<i32>().unwrap_or(0));
@@ -505,8 +508,11 @@ impl Styleable for gtk::Entry {
                     let width = properties.width;
                     let height = properties.height;
                     
-                    if width != 0 && height != 0 {
-                        self.set_size_request(width, height);
+                    if width > 0 || height > 0 {
+                        let normalized_width = if width > 0 { width } else { -1 };
+                        let normalized_height = if height > 0 { height } else { -1 };
+
+                        self.set_size_request(normalized_width, normalized_height);
                     }
 
                     self.set_margin_top(properties.margin_top.parse::<i32>().unwrap_or(0));


### PR DESCRIPTION
Changing only one dimension (width or height) of a TextView/Entry (textarea/input) would not update the size if the other dimension was not changed. Caused by the `width != 0 && height != 0` condition for the set_size_request.

Fix here is just normalizing the width & height, if they are below 0 or not set, they will be set to `-1` (which will make them the default size)