### PR TITLE
Add macOS compile instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,8 @@ What you need is the **Publish** section.
 - for the domain name, choose whatever you want. (example: `duckduckgo`)
 - for the TLD, choose one displayed above the `Result will appear...` label. (example: `rizz`)
 - for the IP, you can either use:
-  - an IP that serves `/index.html` on port 80
-  - a GitHub repository that has `index.html`, **outside any folder**. (example: [registrar](https://github.com/face-hh/webx-registrar)), ***with the `main` default branch***.
+   - an IP that serves `/index.html` on port 80
+   - a GitHub repository that has `index.html`, **outside any folder**. (example: [registrar](https://github.com/face-hh/webx-registrar)), ***with the `main` default branch***.
 
 Don't worry! The IP doesn't have to be valid, and you can save the domain for later!
 

--- a/README.md
+++ b/README.md
@@ -157,8 +157,8 @@ What you need is the **Publish** section.
 - for the domain name, choose whatever you want. (example: `duckduckgo`)
 - for the TLD, choose one displayed above the `Result will appear...` label. (example: `rizz`)
 - for the IP, you can either use:
-- an IP that serves `/index.html` on port 80
-- a GitHub repository that has `index.html`, **outside any folder**. (example: [registrar](https://github.com/face-hh/webx-registrar)), ***with the `main` default branch***.
+  - an IP that serves `/index.html` on port 80
+  - a GitHub repository that has `index.html`, **outside any folder**. (example: [registrar](https://github.com/face-hh/webx-registrar)), ***with the `main` default branch***.
 
 Don't worry! The IP doesn't have to be valid, and you can save the domain for later!
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An alternative to the World Wide Web (`http(s)://`), with:
 - its own **custom browser** written in Rust with [GTK](https://gtk.org/),
-- custom HTML, CSS and **_Lua_** engine (yup, **no javascript! 🎉**),
+- custom HTML, CSS and ***Lua*** engine (yup, **no javascript! 🎉**),
 - custom **DNS** allowing Top-Level domains such as `rizz`, `sigma`, `lol`, `dev`, etc,
 - and **search engine** at `buss://dingle.it`.
 
@@ -52,11 +52,8 @@ home.packages = with pkgs; [
 Then you could just launch it using `webx` in your terminal.
 
 ## Linux
-
 - For now, you have to download [Rust](https://www.rust-lang.org/tools/install). Then, you just need to open `install-linux` as an executable (if you can't execute it, first do `sudo chmod +x ./install-linux`, then you should be able to install).
-
 ## Windows
-
 - Install the executable from the release tab. It's a self-extractor with WinRAR because it has a lot of DLLs.
 
 # Download and Compile
@@ -134,7 +131,6 @@ cargo run
 ```
 
 # Register website
-
 Please follow [How to code a Buss site](https://facedev.gitbook.io/bussin-web-x-how-to-make-a-website/) for a better visual guide.
 
 So you wish to publish a website to Web X? Great! Let's go through the rules:
@@ -162,7 +158,7 @@ What you need is the **Publish** section.
 - for the TLD, choose one displayed above the `Result will appear...` label. (example: `rizz`)
 - for the IP, you can either use:
   - an IP that serves `/index.html` on port 80
-  - a GitHub repository that has `index.html`, **outside any folder**. (example: [registrar](https://github.com/face-hh/webx-registrar)), **_with the `main` default branch_**.
+  - a GitHub repository that has `index.html`, **outside any folder**. (example: [registrar](https://github.com/face-hh/webx-registrar)), ***with the `main` default branch***.
 
 Don't worry! The IP doesn't have to be valid, and you can save the domain for later!
 
@@ -175,12 +171,10 @@ Bussin Napture fetches `index.html` at whatever path you give it. For example, i
 ```bash
 python -m http.server 3000
 ```
-
 2. CLI support with `./napture file:///home/path/to/folder`.
 3. Enter `file:///home/path/to/folder` in the search bar.
 
 # HTML guide
-
 The supported tags are: `head`, `title`, `link`, `meta`, `script`, `h1`-`h6`, `div`, `p`, `ul`, `ol`, `li`, `div`, `button`, `hr`, `img`, `input`, `textarea`, `button`, `select`, `option`. Keep in mind their syntax may be different if you're already familiar with HTML5 (i.e. `link` is used for the tab icon). Please check [registrar](https://github.com/face-hh/webx-registrar) or `/napture/test/index.html` for examples.
 
 # CSS guide

--- a/README.md
+++ b/README.md
@@ -1,22 +1,27 @@
 # Bussin Web X
 
 An alternative to the World Wide Web (`http(s)://`), with:
+
 - its own **custom browser** written in Rust with [GTK](https://gtk.org/),
-- custom HTML, CSS and ***Lua*** engine (yup, **no javascript! 🎉**),
+- custom HTML, CSS and **_Lua_** engine (yup, **no javascript! 🎉**),
 - custom **DNS** allowing Top-Level domains such as `rizz`, `sigma`, `lol`, `dev`, etc,
 - and **search engine** at `buss://dingle.it`.
 
 ![Preview of buss://register.it, the frontend for registering domains](.github_assets/image.png)
 
 # File structure
+
 - `/napture` - The source code for the **browser** Bussin Napture, used to view buss:// sites.
 - `/dns` - The source code for the **DNS** (Domain Name System), used for the API at `https://api.buss.lol`
 - `/dingle` - The source code for the official **search engine** (API) of Web X. For the frontend, check [dingle frontend repo](https://github.com/face-hh/dingle-frontend)
 - [registrar](https://github.com/face-hh/webx-registrar) - The source code for `buss://register.it`, frontend for `https://api.buss.lol` made for Bussin Web X. This can also serve as an example for how buss:// sites are made.
 
 # Download and Install
+
 ## Arch Linux
+
 - `yay -S napture`, it's available on AUR.
+
 ## Nix[OS]
 
 **Flakes**: The repository provides a flake which exposes an overlay providing the webx package, so you could just add the input in your flake.nix file
@@ -52,17 +57,24 @@ home.packages = with pkgs; [
 Then you could just launch it using `webx` in your terminal.
 
 ## Linux
+
 - For now, you have to download [Rust](https://www.rust-lang.org/tools/install). Then, you just need to open `install-linux` as an executable (if you can't execute it, first do `sudo chmod +x ./install-linux`, then you should be able to install).
+
 ## Windows
+
 - Install the executable from the release tab. It's a self-extractor with WinRAR because it has a lot of DLLs.
 
 # Download and Compile
+
 ## Linux
+
 Install [Rust](https://www.rust-lang.org/tools/install) if you haven't already.
 It should work by default, but if you're getting errors such as "missing PC files", you should Google it. Most likely you just have to install a library
 
 ## Windows
+
 Welcome to Gaming OS 🙂
+
 1. Download [Rust](https://www.rust-lang.org/tools/install)
 2. Download GNU target: `rustup toolchain install stable-gnu && rustup default stable-gnu`
 3. Download [MSYS32](https://www.msys2.org/)
@@ -73,7 +85,66 @@ Welcome to Gaming OS 🙂
 8. Select `Path` -> Click on `Edit` -> Add the following three entries: `C:\msys64\mingw64\include`, `C:\msys64\mingw64\bin`, and `C:\msys64\mingw64\lib`.
 9. Open a terminal in the folder with `napture/`, run `cargo run`.
 
+## MacOS (Apple Silicon)
+
+1. Install [Rust](https://www.rust-lang.org/tools/install)
+2. Install [Homebrew](https://brew.sh/)
+3. Install PKG_CONFIG_PATH and ensure it's set in your path
+
+```bash
+brew install pkg-config
+which pkg-config
+```
+
+3.1. Should return something like `/opt/homebrew/bin/pkg-config`. If it doesn't, add it to your path.
+
+4. Install GTK and Necessary Libraries
+
+```bash
+brew install glib
+brew install gobject-introspection
+brew install graphene
+brew install gdk-pixbuf
+brew install pango
+brew install gtk+4
+brew install libadwaita
+brew install lua@5.4
+
+brew --prefix glib
+brew --prefix gobject-introspection
+brew --prefix graphene
+brew --prefix gdk-pixbuf
+brew --prefix pango
+brew --prefix gtk4
+brew --prefix libadwaita
+brew --prefix lua@5.4
+```
+
+4.1 Validate if the libraries are installed adequately and set in PKG_CONFIG_PATH, command below should return the path to the libraries without any errors.
+
+```bash
+pkg-config --libs --cflags glib-2.0
+pkg-config --libs --cflags gobject-2.0
+pkg-config --libs --cflags graphene-gobject-1.0
+pkg-config --libs --cflags gdk-pixbuf-2.0
+pkg-config --libs --cflags pango
+pkg-config --libs --cflags gtk4
+pkg-config --libs --cflags libadwaita-1
+pkg-config --libs --cflags lua-5.4
+```
+
+5. Run `cargo run` in the `napture/` directory.
+
+```bash
+cd napture
+
+cargo build
+# or
+cargo run
+```
+
 # Register website
+
 Please follow [How to code a Buss site](https://facedev.gitbook.io/bussin-web-x-how-to-make-a-website/) for a better visual guide.
 
 So you wish to publish a website to Web X? Great! Let's go through the rules:
@@ -97,31 +168,38 @@ You will see this interface.
 ![Preview of buss://register.it, the frontend for registering domains](.github_assets/image.png)
 
 What you need is the **Publish** section.
+
 - for the domain name, choose whatever you want. (example: `duckduckgo`)
 - for the TLD, choose one displayed above the `Result will appear...` label. (example: `rizz`)
 - for the IP, you can either use:
-   - an IP that serves `/index.html` on port 80
-   - a GitHub repository that has `index.html`, **outside any folder**. (example: [registrar](https://github.com/face-hh/webx-registrar)), ***with the `main` default branch***.
+  - an IP that serves `/index.html` on port 80
+  - a GitHub repository that has `index.html`, **outside any folder**. (example: [registrar](https://github.com/face-hh/webx-registrar)), **_with the `main` default branch_**.
 
 Don't worry! The IP doesn't have to be valid, and you can save the domain for later!
 
 **WARNING**: After creating the domain, you'll be shown a **secret key**. Please make sure to save it as you will need it to Update/Delete your domain.
 
 # Run website locally
+
 Bussin Napture fetches `index.html` at whatever path you give it. For example, if you enter `http://localhost:3000`, Napture will fetch `http://localhost:3000/index.html`. From the index.html, if you have further `<link>` or `<script>` imports, they will be fetched at `http://localhost:3000/file.(css|lua)`.
 
 1. To locally test a website, you can use something like [Python](https://www.python.org/):
+
 ```bash
 python -m http.server 3000
 ```
+
 2. CLI support with `./napture file:///home/path/to/folder`.
 3. Enter `file:///home/path/to/folder` in the search bar.
 
 # HTML guide
+
 The supported tags are: `head`, `title`, `link`, `meta`, `script`, `h1`-`h6`, `div`, `p`, `ul`, `ol`, `li`, `div`, `button`, `hr`, `img`, `input`, `textarea`, `button`, `select`, `option`. Keep in mind their syntax may be different if you're already familiar with HTML5 (i.e. `link` is used for the tab icon). Please check [registrar](https://github.com/face-hh/webx-registrar) or `/napture/test/index.html` for examples.
 
 # CSS guide
+
 The supported properties are:
+
 - `border-color`
 - `border-width`
 - `border-style`
@@ -151,7 +229,9 @@ The supported properties are:
 Properties whose value type wasn't specified are either measured in `px`, or are colors (`#fff`, `red`, etc.)
 
 # Lua guide
+
 For those coming from the traditional web...
+
 ```diff
 - 1. const test = document.querySelector(".classExample");
 - 2. test.textContent = "abc";

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Bussin Web X
 
 An alternative to the World Wide Web (`http(s)://`), with:
-
 - its own **custom browser** written in Rust with [GTK](https://gtk.org/),
 - custom HTML, CSS and **_Lua_** engine (yup, **no javascript! 🎉**),
 - custom **DNS** allowing Top-Level domains such as `rizz`, `sigma`, `lol`, `dev`, etc,
@@ -10,18 +9,14 @@ An alternative to the World Wide Web (`http(s)://`), with:
 ![Preview of buss://register.it, the frontend for registering domains](.github_assets/image.png)
 
 # File structure
-
 - `/napture` - The source code for the **browser** Bussin Napture, used to view buss:// sites.
 - `/dns` - The source code for the **DNS** (Domain Name System), used for the API at `https://api.buss.lol`
 - `/dingle` - The source code for the official **search engine** (API) of Web X. For the frontend, check [dingle frontend repo](https://github.com/face-hh/dingle-frontend)
 - [registrar](https://github.com/face-hh/webx-registrar) - The source code for `buss://register.it`, frontend for `https://api.buss.lol` made for Bussin Web X. This can also serve as an example for how buss:// sites are made.
 
 # Download and Install
-
 ## Arch Linux
-
 - `yay -S napture`, it's available on AUR.
-
 ## Nix[OS]
 
 **Flakes**: The repository provides a flake which exposes an overlay providing the webx package, so you could just add the input in your flake.nix file
@@ -65,16 +60,12 @@ Then you could just launch it using `webx` in your terminal.
 - Install the executable from the release tab. It's a self-extractor with WinRAR because it has a lot of DLLs.
 
 # Download and Compile
-
 ## Linux
-
 Install [Rust](https://www.rust-lang.org/tools/install) if you haven't already.
 It should work by default, but if you're getting errors such as "missing PC files", you should Google it. Most likely you just have to install a library
 
 ## Windows
-
 Welcome to Gaming OS 🙂
-
 1. Download [Rust](https://www.rust-lang.org/tools/install)
 2. Download GNU target: `rustup toolchain install stable-gnu && rustup default stable-gnu`
 3. Download [MSYS32](https://www.msys2.org/)
@@ -86,7 +77,6 @@ Welcome to Gaming OS 🙂
 9. Open a terminal in the folder with `napture/`, run `cargo run`.
 
 ## MacOS (Apple Silicon)
-
 1. Install [Rust](https://www.rust-lang.org/tools/install)
 2. Install [Homebrew](https://brew.sh/)
 3. Install PKG_CONFIG_PATH and ensure it's set in your path
@@ -168,7 +158,6 @@ You will see this interface.
 ![Preview of buss://register.it, the frontend for registering domains](.github_assets/image.png)
 
 What you need is the **Publish** section.
-
 - for the domain name, choose whatever you want. (example: `duckduckgo`)
 - for the TLD, choose one displayed above the `Result will appear...` label. (example: `rizz`)
 - for the IP, you can either use:
@@ -180,11 +169,9 @@ Don't worry! The IP doesn't have to be valid, and you can save the domain for la
 **WARNING**: After creating the domain, you'll be shown a **secret key**. Please make sure to save it as you will need it to Update/Delete your domain.
 
 # Run website locally
-
 Bussin Napture fetches `index.html` at whatever path you give it. For example, if you enter `http://localhost:3000`, Napture will fetch `http://localhost:3000/index.html`. From the index.html, if you have further `<link>` or `<script>` imports, they will be fetched at `http://localhost:3000/file.(css|lua)`.
 
 1. To locally test a website, you can use something like [Python](https://www.python.org/):
-
 ```bash
 python -m http.server 3000
 ```
@@ -197,9 +184,7 @@ python -m http.server 3000
 The supported tags are: `head`, `title`, `link`, `meta`, `script`, `h1`-`h6`, `div`, `p`, `ul`, `ol`, `li`, `div`, `button`, `hr`, `img`, `input`, `textarea`, `button`, `select`, `option`. Keep in mind their syntax may be different if you're already familiar with HTML5 (i.e. `link` is used for the tab icon). Please check [registrar](https://github.com/face-hh/webx-registrar) or `/napture/test/index.html` for examples.
 
 # CSS guide
-
 The supported properties are:
-
 - `border-color`
 - `border-width`
 - `border-style`
@@ -229,9 +214,7 @@ The supported properties are:
 Properties whose value type wasn't specified are either measured in `px`, or are colors (`#fff`, `red`, etc.)
 
 # Lua guide
-
 For those coming from the traditional web...
-
 ```diff
 - 1. const test = document.querySelector(".classExample");
 - 2. test.textContent = "abc";

--- a/README.md
+++ b/README.md
@@ -157,8 +157,8 @@ What you need is the **Publish** section.
 - for the domain name, choose whatever you want. (example: `duckduckgo`)
 - for the TLD, choose one displayed above the `Result will appear...` label. (example: `rizz`)
 - for the IP, you can either use:
-  - an IP that serves `/index.html` on port 80
-  - a GitHub repository that has `index.html`, **outside any folder**. (example: [registrar](https://github.com/face-hh/webx-registrar)), ***with the `main` default branch***.
+- an IP that serves `/index.html` on port 80
+- a GitHub repository that has `index.html`, **outside any folder**. (example: [registrar](https://github.com/face-hh/webx-registrar)), ***with the `main` default branch***.
 
 Don't worry! The IP doesn't have to be valid, and you can save the domain for later!
 


### PR DESCRIPTION
This PR adds detailed installation instructions for macOS (Apple Silicon) to the README file. The new section includes steps for installing Rust, Homebrew, required libraries, and setting up the environment for compiling and running the project.

Changes:
	 •  Added macOS (Apple Silicon) section under “Download and Install” in README.