### PR TITLE
Auto set required environment variable HOMEBREW_CELLAR for `install-macos`

### DIFF
--- a/install-macos
+++ b/install-macos
@@ -21,6 +21,19 @@ brew install gtk4 graphene glib libadwaita lua pkg-config || exit 1
 # Assuming the script is in the same directory as "napture"
 cd "$(dirname "$0")/napture" || exit 1
 
+# Specifies required environment variable HOMEBREW_CELLAR when it is not set
+arch_name=$(uname -m)
+if [ "$arch_name" = "x86_64" ]; then
+  # Intel Mac
+  export HOMEBREW_CELLAR="/usr/local/Cellar"
+elif [ "$arch_name" = "arm64" ]; then
+  # Apple Silicon Mac
+  export HOMEBREW_CELLAR="/opt/homebrew/Cellar"
+else
+  echo "Unsupported architecture: $arch_name"
+  exit 1
+fi
+
 # Build the project
 RUSTFLAGS="-L $HOMEBREW_CELLAR" cargo build --release || exit 1
 


### PR DESCRIPTION
When I first run `./install-macos` on my machine I got an unexpected error, which turned out that the original scripts tried to refer to the environment variable `HOMEBREW_CELLAR`, but I didn't explicitly set that env on my machine. I just added some lines of code so that the install scripts can automatically detects and sets the correct env for the current machine. 

This could avoid crashes in cases like me.