### PR TITLE
Create PKGBUILD and fixed licensing issues..

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -5,7 +5,8 @@ pkgdesc="An alternative for the World Wide Web"
 arch=('x86_64')
 url="https://github.com/face-hh/webx"
 license=('Apache-2.0')
-depends=('glib2' 'cargo' 'gtk4' 'libadwaita' 'lua')
+depends=('glib2' 'gtk4' 'libadwaita' 'lua')
+makedepends=('cargo')
 source=("git+${url}.git#tag=v${pkgver}")
 sha256sums=('SKIP')
 build() {

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 pkgname=napture
 pkgver=1.2.2
 pkgrel=1
-pkgdesc="Napture is a simple browser using a modified version of the http protocol called buss, it uses Lua instead of JavaScript and has support for most HTML and CSS tags, it uses a custom DNS found at api.buss.lol."
+pkgdesc="An alternative for the World Wide Web"
 arch=('x86_64')
 url="https://github.com/face-hh/webx"
 license=('Apache-2.0')

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,33 @@
+pkgname=napture
+pkgver=1.2.2
+pkgrel=1
+pkgdesc="Napture is a simple browser using a modified version of the http protocol called buss, it uses Lua instead of JavaScript and has support for most HTML and CSS tags, it uses a custom DNS found at api.buss.lol."
+arch=('x86_64')
+url="https://github.com/face-hh/webx"
+license=('Apache-2.0')
+depends=('glib2' 'cargo' 'gtk4' 'libadwaita' 'lua')
+source=("git+${url}.git#tag=v${pkgver}")
+sha256sums=('SKIP')
+build() {
+    cd "$srcdir/webx/napture"
+    cargo build --release
+}
+
+package() {
+    cd "$srcdir/webx/napture"
+    install -Dm755 "target/release/webx" "$pkgdir/usr/bin/napture"
+    install -Dm644 "file.png" "$pkgdir/usr/share/pixmaps/napture.png"
+
+	mkdir -p "$pkgdir/usr/share/applications"
+	
+    # Desktop entry
+    cat << EOF > "$pkgdir/usr/share/applications/napture.desktop"
+[Desktop Entry]
+Name=Napture
+Comment=Napture is a simple browser using a modified version of the http protocol called buss, it uses Lua instead of JavaScript and has support for most HTML and CSS tags, it uses a custom DNS found at api.buss.lol.
+Exec=napture
+Icon=napture
+Type=Application
+Categories=Internet;
+EOF
+}

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -16,18 +16,7 @@ build() {
 package() {
     cd "$srcdir/webx/napture"
     install -Dm755 "target/release/webx" "$pkgdir/usr/bin/napture"
-    install -Dm644 "file.png" "$pkgdir/usr/share/pixmaps/napture.png"
-
-	mkdir -p "$pkgdir/usr/share/applications"
-	
-    # Desktop entry
-    cat << EOF > "$pkgdir/usr/share/applications/napture.desktop"
-[Desktop Entry]
-Name=Napture
-Comment=Napture is a simple browser using a modified version of the http protocol called buss, it uses Lua instead of JavaScript and has support for most HTML and CSS tags, it uses a custom DNS found at api.buss.lol.
-Exec=napture
-Icon=napture
-Type=Application
-Categories=Internet;
-EOF
+    install -Dm644 "io.github.face_hh.Napture.metainfo.xml" -t "$pkgdir/usr/share/metainfo/"
+    install -Dm644 "io.github.face_hh.Napture.desktop" -t "$pkgdir/usr/share/applications/"
+    install -Dm644 "io.github.face_hh.Napture.svg" -t "$pkgdir/usr/share/icons/hicolor/scalable/apps/"
 }


### PR DESCRIPTION
This pull request addresses the issue regarding the use of Apache2 as a license identifier in the PKGBUILD script for the napture package. As per recent updates, Apache2 is no longer recognized as a valid SPDX license identifier. To resolve this, I've updated the license entry to comply with SPDX standards.

Key Changes:

License:
Updated the license entry in the PKGBUILD script from Apache2 to Apache-2.0, aligning with the SPDX License List (https://spdx.org/licenses/) and Arch Linux packaging guidelines (https://wiki.archlinux.org/title/PKGBUILD#license).