### PR TITLE
Hot fix for #187, unable to parse IPs

### DIFF
--- a/napture/src/main.rs
+++ b/napture/src/main.rs
@@ -611,7 +611,16 @@ fn fetch_dns(url: String) -> String {
         if let Ok(json) = response.json::<DomainInfo>() {
             let path = url.split_once('/')
                 .unwrap_or(("", "")).1;
-            json.ip + &format!("/{}", path)
+            
+            //check if json.ip is a standalone IP address,
+            //if so, prepend "http://" to make it parsable
+            //as a url.
+            let ip = match json.ip.parse::<std::net::IpAddr>() {
+                Ok(_ip) => format!("http://{}", json.ip),
+                Err(_) => json.ip.clone(),
+            };
+
+            ip + &format!("/{}", path)
         } else {
             lualog!(
                 "debug",


### PR DESCRIPTION
Fixes IP not recognised as url in the browser when fetching site contents via http and when affixing /index.html to url.