### PR TITLE
FIX: Creation of domains without name

### DIFF
--- a/dns/src/http/routes.rs
+++ b/dns/src/http/routes.rs
@@ -19,10 +19,10 @@ pub(crate) async fn index() -> impl Responder {
 pub(crate) async fn create_logic(domain: Domain, app: &AppState) -> Result<Domain, HttpResponse> {
     helpers::validate_ip(&domain)?;
 
-    if !app.config.tld_list().contains(&domain.tld.as_str()) || !domain.name.chars().all(|c| c.is_alphabetic() || c == '-') || domain.name.len() > 24 {
+    if !app.config.tld_list().contains(&domain.tld.as_str()) || !domain.name.chars().all(|c| c.is_alphabetic() || c == '-') || domain.name.len() > 24 || domain.name.len() < 1 {
         return Err(HttpResponse::BadRequest().json(Error {
             msg: "Failed to create domain",
-            error: "Invalid name, non-existent TLD, or name too long (24 chars).".into(),
+            error: "Invalid name, non-existent TLD, or invalid length for name (1 - 24 chars).".into(),
         }));
     }
 


### PR DESCRIPTION
Fix for #192 
This pr makes sure domains have at least one letter in the name