### PR TITLE
Added <avatar> object

### DIFF
--- a/napture/Cargo.lock
+++ b/napture/Cargo.lock
@@ -2121,7 +2121,7 @@ dependencies = [
 
 [[package]]
 name = "webx"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "base64",
  "chrono",

--- a/napture/Cargo.toml
+++ b/napture/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webx"
-version = "1.2.2"
+version = "1.3.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/napture/src/main.rs
+++ b/napture/src/main.rs
@@ -495,7 +495,7 @@ fn make_tab(
         let dialog = gtk::AboutDialog::builder()
             .modal(true)
             .program_name("Bussin Napture")
-            .version("v1.2.2")
+            .version("v1.3.0")
             .website("https://github.com/face-hh/webx")
             .website_label("GitHub")
             .license_type(gtk::License::Apache20)

--- a/napture/src/resources/not_found.html
+++ b/napture/src/resources/not_found.html
@@ -7,10 +7,12 @@
 </head>
 
 <body>
-    <img src="https://i.imgur.com/GXSz3Gz.png"/>
-    <h1>The website doesn't exist :(</h1>
+    <div class="sadge">
+        <img src="https://i.imgur.com/GXSz3Gz.png"/>
+        <h1>The website doesn't exist :(</h1>
 
-    <a href="buss://dingle.it">Go to the search engine?</a>
+        <a href="buss://dingle.it">Go to the search engine?</a>
+    </div>
 </body>
 
 </html>

--- a/napture/src/resources/not_found.html
+++ b/napture/src/resources/not_found.html
@@ -7,12 +7,10 @@
 </head>
 
 <body>
-    <div class="sadge">
-        <img src="https://i.imgur.com/GXSz3Gz.png"/>
-        <h1>The website doesn't exist :(</h1>
+    <img src="https://i.imgur.com/GXSz3Gz.png"/>
+    <h1>The website doesn't exist :(</h1>
 
-        <a href="buss://dingle.it">Go to the search engine?</a>
-    </div>
+    <a href="buss://dingle.it">Go to the search engine?</a>
 </body>
 
 </html>

--- a/napture/src/resources/notfound.css
+++ b/napture/src/resources/notfound.css
@@ -1,3 +1,0 @@
-sadge {
-  align-items: center;
-}

--- a/napture/src/resources/notfound.css
+++ b/napture/src/resources/notfound.css
@@ -1,0 +1,3 @@
+sadge {
+  align-items: center;
+}


### PR DESCRIPTION
![grafik](https://github.com/face-hh/webx/assets/95766563/1b6c5c06-7b92-4f44-b521-df4cac628956)
(Ignore the first five commits)

# Let me introduce the newest technology in webx: Avatars!
Utilizing the libadwaita avatar object, you can now add avatars directly to your webpage using the <avatar> tag. Here's how it works.

`<avatar size="caseoh" text="Case Oh" src="path/to/caseoh.png"/>`

### Size
This attribute controls the size of the avatar object. There are a select few pre-set sizes.
- xs = 16
- s = 32
- m = 48 (default)
- l = 64
- xl = 96
- caseoh = 1024

Additionally, if a number is entered, the size will be set to that. If not defined, it will default to 48.

### Text
This attribute is used to show initials on the avatar. This is only really useful if you don't apply an image to the avatar. If not defined, an avatar icon will be shown.

### Src
This attribute defines the image set in the avatar. If not defined, the default icon/initials will be used. 